### PR TITLE
[tech] CSS - Revue du CSS (bootstrap + inline style) #686

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,28 @@
   <a href="https://blog.getbootstrap.com/">Blog</a>
 </p>
 
+## Smartloc usage
 
-## Table of contents
+### Build
+
+Compilation & build des fichiers css
+```shell
+npm run smartloc-dist
+```
+
+Copie des fichiers résultant dans le repo Smartloc (doit être au même niveau que le repo Boostrap)
+```shell
+npm run smartloc-copy
+```
+
+Pour comparer le fichier minifié résultant : `bootstrap-smartloc.min.css` on peut utiliser l'outil suivant :
+https://platform.text.com/tools/diff-checker
+
+L'outil ne collapse pas les lignes identiques, il faut faire une rehcerhce dans le HTML de la page pour trouver les éléments ajoutés ou supprimés : 
+- ajoutés  :ctrl+F : rgb(53, 229, 113)
+- supprimés : ctrl+F : rgb(229, 53, 53)
+
+## Bootstrap - Table of contents
 
 - [Quick start](#quick-start)
 - [Status](#status)

--- a/scss/_smartloc.scss
+++ b/scss/_smartloc.scss
@@ -837,8 +837,12 @@ p + .cardLigne {
   border: $card-border-width solid $card-border-color !important;
 }
 
-.card_active{
+.card_active:not(.outline){
   border:6px solid #a896d8;
+}
+
+.card_active.outline{
+  outline:6px solid #a896d8;
 }
 
 /************* ICONES *************/

--- a/scss/_toasts.scss
+++ b/scss/_toasts.scss
@@ -1,4 +1,9 @@
 .toast {
+  position:fixed;
+  top: 30px;
+  right: 100px;
+  z-index: 2;
+  cursor: pointer;
   max-width: $toast-max-width;
   overflow: hidden; // cheap rounded corners on nested items
   @include font-size($toast-font-size);


### PR DESCRIPTION
### Résumé

Dans le but de limiter le CSS inline dans le repo `bailtype`, cette PR ajoute une classe `.outline` et enrichit une classe existante `.toast`

J'ai mis à jour aussi le README pour rappeler les commandes de build et renseigner un outil de diff qui peut être utile quand on modifie le fichier minifié.

Cette PR est à merger si le fichier `min.css` résultant est bien accepté dans le repo `smartloc`, pour éviter les nouvelles incohérences entre la prod et le repo